### PR TITLE
Fix ChaCha20 nonce endianness

### DIFF
--- a/src/main/java/com/southernstorm/noise/crypto/ChaChaCore.java
+++ b/src/main/java/com/southernstorm/noise/crypto/ChaChaCore.java
@@ -22,6 +22,9 @@
 
 package com.southernstorm.noise.crypto;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 /**
  * Implementation of the ChaCha20 core hash transformation.
  */

--- a/src/main/java/com/southernstorm/noise/crypto/ChaChaCore.java
+++ b/src/main/java/com/southernstorm/noise/crypto/ChaChaCore.java
@@ -75,6 +75,19 @@ public final class ChaChaCore {
 		return (key[offset] & 0xFF) | ((key[offset + 1] & 0xFF) << 8) | ((key[offset + 2] & 0xFF) << 16) | ((key[offset + 3] & 0xFF) << 24);
 	}
 
+	private static int toLittleEndian(int n)
+	{
+		ByteBuffer buffer = ByteBuffer.allocate(4);
+
+		buffer.order(ByteOrder.BIG_ENDIAN);
+		buffer.putInt(n);
+
+		buffer.order(ByteOrder.LITTLE_ENDIAN);
+		buffer.rewind();
+
+		return buffer.getInt();
+	}
+
 	/**
 	 * Initializes a ChaCha20 block with a 128-bit key.
 	 * 
@@ -145,8 +158,8 @@ public final class ChaChaCore {
 	{
 		output[12] = 0;
 		output[13] = 0;
-		output[14] = (int)iv;
-		output[15] = (int)(iv >> 32);
+		output[14] = toLittleEndian((int) (iv >> 32));
+		output[15] = toLittleEndian((int) (iv & 0xFFFFFFFFL));
 	}
 	
 	/**
@@ -162,8 +175,8 @@ public final class ChaChaCore {
 	{
 		output[12] = (int)counter;
 		output[13] = (int)(counter >> 32);
-		output[14] = (int)iv;
-		output[15] = (int)(iv >> 32);
+		output[14] = toLittleEndian((int) (iv >> 32));
+		output[15] = toLittleEndian((int) (iv & 0xFFFFFFFFL));
 	}
 	
 	private static int leftRotate16(int v)


### PR DESCRIPTION
This pull request is aimed at fixing a bug with ChaCha20-Poly1305 cipher state that makes it incompatible with any other ChaCha20-Poly1305 implementation (including the Java 11 built-in one) because of incorrect nonce handling.

According to the specification, nonce should be little endian but the original implementation does not properly convert Java big endian 64-bit integer to a little endian one.
